### PR TITLE
Welling/testing process fixes

### DIFF
--- a/src/soft_assay_rules/local_rule_tester.py
+++ b/src/soft_assay_rules/local_rule_tester.py
@@ -22,7 +22,7 @@ from rule_chain import (
     RuleLogicException,
 )
 
-from rule_generator import CHAIN_OUTPUT_PATH as CHAIN_INPUT_PATH
+CHAIN_INPUT_PATH = Path(__file__).parent / "testing_rule_chain.json"
 
 rule_chain = None
 

--- a/src/soft_assay_rules/testing_rule_chain.json
+++ b/src/soft_assay_rules/testing_rule_chain.json
@@ -85,7 +85,7 @@
     },
     {
         "type": "match",
-        "match": "not_dcwg and is_derived and data_types[0] in ['codex_cytokit_v1'] and [elt for elt in dag_provenance_list if elt !~~ 'anndata']",
+        "match": "not_dcwg and is_derived and data_types[0] in ['codex_cytokit_v1'] and not [elt for elt in dag_provenance_list if elt =~~ 'anndata']",
         "value": "{'assaytype': 'codex_cytokit_v1', 'vitessce-hints': ['codex', 'is_image', 'is_tiled', 'json_based'], 'primary': false, 'contains-pii': false, 'description': 'CODEX [Cytokit + SPRM]'}",
         "rule_description": "non-DCWG derived codex_cytokit_v1 json-based"
     },
@@ -409,7 +409,7 @@
     },
     {
         "type": "match",
-        "match": "not_dcwg and is_derived and data_types[0] in ['salmon_sn_rnaseq_10x', 'salmon_rnaseq_10x_sn', 'salmon_rnaseq_10x_v2_sn'] and [elt for elt in dag_provenance_list if elt !~~ 'anndata']",
+        "match": "not_dcwg and is_derived and data_types[0] in ['salmon_sn_rnaseq_10x', 'salmon_rnaseq_10x_sn', 'salmon_rnaseq_10x_v2_sn'] and not [elt for elt in dag_provenance_list if elt =~~ 'anndata']",
         "value": "{'assaytype': 'salmon_sn_rnaseq_10x', 'vitessce-hints': ['is_sc', 'rna', 'json_based'], 'primary': false, 'contains-pii': false, 'description': 'snRNA-seq [Salmon]'}",
         "rule_description": "non-DCWG derived salmon_sn_rnaseq_10x json-based"
     },


### PR DESCRIPTION
The testing routines were taking their input rule chain from the output location of rule_generator.py .  Since rule_generator is now deprecated, this seems incorrect.  This PR modifies things to that the rule chain to be tested is the current version, in src/soft_assay_rules/testing_rule_chain.json .

In the process of making this fix it was noted that there were two rules that operated correctly because of their order in the chain rather than because of the actual test they were performing.  This PR also corrects those rules.