### PR TITLE
General: Add 'is-multi-assay' bool to make it easier for index code t…

### DIFF
--- a/src/soft_assay_rules/rule_generator.py
+++ b/src/soft_assay_rules/rule_generator.py
@@ -272,7 +272,8 @@ def main() -> None:
                        f" 'contains-pii': true,"
                        f" 'primary': true,"
                        f" 'dataset-type': '{data_type}',"
-                       f" 'must-contain': [{must_contain_str}]"
+                       f" 'must-contain': [{must_contain_str}],"
+                       f" 'is-multi-assay': true"
                        "}"
                        ),
              "rule_description": f"DCWG {assay}"
@@ -296,7 +297,8 @@ def main() -> None:
                        f" 'contains-pii': true,"
                        f" 'primary': true,"
                        f" 'dataset-type': '{data_type}',"
-                       f" 'must-contain': [{must_contain_str}]"
+                       f" 'must-contain': [{must_contain_str}],"
+                       f" 'is-multi-assay': true"
                        "}"
                        ),
              "rule_description": f"DCWG {assay}"
@@ -320,7 +322,8 @@ def main() -> None:
                        f" 'contains-pii': true,"
                        f" 'primary': true,"
                        f" 'dataset-type': '{data_type}',"
-                       f" 'must-contain': [{must_contain_str}]"
+                       f" 'must-contain': [{must_contain_str}],"
+                       f" 'is-multi-assay': true"
                        "}"
                        ),
              "rule_description": f"DCWG {assay}"

--- a/src/soft_assay_rules/testing_rule_chain.json
+++ b/src/soft_assay_rules/testing_rule_chain.json
@@ -488,31 +488,31 @@
     {
         "type": "match",
         "match": "is_dcwg and dataset_type == 'Visium (no probes)'",
-        "value": "{'assaytype': 'visium-no-probes', 'vitessce-hints': [], 'dir-schema': 'visium-no-probes-v2', 'description': 'Visium (No probes)', 'contains-pii': true, 'primary': true, 'dataset-type': 'Visium (no probes)', 'must-contain': ['Histology','RNAseq']}",
+        "value": "{'assaytype': 'visium-no-probes', 'vitessce-hints': [], 'dir-schema': 'visium-no-probes-v2', 'description': 'Visium (No probes)', 'contains-pii': true, 'primary': true, 'dataset-type': 'Visium (no probes)', 'must-contain': ['Histology','RNAseq'], 'is-multi-assay': true}",
         "rule_description": "DCWG visium-no-probes"
     },
     {
         "type": "match",
         "match": "is_dcwg and dataset_type == 'Visium (with probes)'",
-        "value": "{'assaytype': 'visium-with-probes', 'vitessce-hints': [], 'dir-schema': 'visium-with-probes-v2', 'description': 'Visium (With probes)', 'contains-pii': true, 'primary': true, 'dataset-type': 'Visium (with probes)', 'must-contain': ['Histology','RNAseq (with probes)']}",
+        "value": "{'assaytype': 'visium-with-probes', 'vitessce-hints': [], 'dir-schema': 'visium-with-probes-v2', 'description': 'Visium (With probes)', 'contains-pii': true, 'primary': true, 'dataset-type': 'Visium (with probes)', 'must-contain': ['Histology','RNAseq (with probes)'], 'is-multi-assay': true}",
         "rule_description": "DCWG visium-with-probes"
     },
     {
         "type": "match",
         "match": "is_dcwg and dataset_type == 'GeoMx (NGS)'",
-        "value": "{'assaytype': 'geomx_ngs?', 'vitessce-hints': [], 'dir-schema': 'geomx-ngs-v2', 'description': 'GeoMx (NGS)', 'contains-pii': true, 'primary': true, 'dataset-type': 'GeoMx (NGS)', 'must-contain': ['RNAseq']}",
+        "value": "{'assaytype': 'geomx_ngs?', 'vitessce-hints': [], 'dir-schema': 'geomx-ngs-v2', 'description': 'GeoMx (NGS)', 'contains-pii': true, 'primary': true, 'dataset-type': 'GeoMx (NGS)', 'must-contain': ['RNAseq'], 'is-multi-assay': true}",
         "rule_description": "DCWG geomx_ngs?"
     },
     {
         "type": "match",
         "match": "is_dcwg and dataset_type == '10X Multiome'",
-        "value": "{'assaytype': '10x-multiome', 'vitessce-hints': [], 'dir-schema': '10x-multiome-v2', 'description': '10X Multiome', 'contains-pii': true, 'primary': true, 'dataset-type': '10X Multiome', 'must-contain': ['RNAseq','ATACseq']}",
+        "value": "{'assaytype': '10x-multiome', 'vitessce-hints': [], 'dir-schema': '10x-multiome-v2', 'description': '10X Multiome', 'contains-pii': true, 'primary': true, 'dataset-type': '10X Multiome', 'must-contain': ['RNAseq','ATACseq'], 'is-multi-assay': true}",
         "rule_description": "DCWG 10x-multiome"
     },
     {
         "type": "match",
         "match": "is_dcwg and dataset_type == 'SNARE-seq2'",
-        "value": "{'assaytype': 'multiome-snare-seq2', 'vitessce-hints': [], 'dir-schema': 'snareseq2-v2', 'description': 'SNARE-seq2', 'contains-pii': true, 'primary': true, 'dataset-type': 'SNARE-seq2', 'must-contain': ['RNAseq','ATACseq']}",
+        "value": "{'assaytype': 'multiome-snare-seq2', 'vitessce-hints': [], 'dir-schema': 'snareseq2-v2', 'description': 'SNARE-seq2', 'contains-pii': true, 'primary': true, 'dataset-type': 'SNARE-seq2', 'must-contain': ['RNAseq','ATACseq'], 'is-multi-assay': true}",
         "rule_description": "DCWG multiome-snare-seq2"
     },
     {
@@ -728,7 +728,7 @@
     {
         "type": "match",
         "match": "is_dcwg and is_derived and data_types[0] in ['visium_no_probes']",
-        "value": "{'assaytype': 'visium-no-probes', 'vitessce-hints': [], 'primary': false, 'contains-pii': false, 'description': 'Visium (no probes) [Salmon + Scanpy]'}",
+        "value": "{'assaytype': 'visium-no-probes', 'vitessce-hints': [], 'primary': false, 'contains-pii': false, 'description': 'Visium (no probes) [Salmon + Scanpy]', 'is-multi-assay': true}",
         "rule_description": "non-DCWG derived visium-no-probes"
     }
 ]


### PR DESCRIPTION
…o determine whether something is a multi-assay or not. This is only added for primary multi-assay datasets (IE Visium) and their derived datasets. This is not going to be added for component datasets as we would duplicate rules by a significant amount.