### PR TITLE
SNARE-seq2 [Salmon + ArchR + Muon] update hints

### DIFF
--- a/src/soft_assay_rules/testing_rule_chain.json
+++ b/src/soft_assay_rules/testing_rule_chain.json
@@ -746,7 +746,7 @@
     {
         "type": "match",
         "match": "is_central_processed and data_types[0] in ['multiome_snareseq']",
-        "value": "{'assaytype': 'multiome-snare-seq2', 'vitessce-hints': ['rna', 'is_image', 'anndata', 'spatial'], 'primary': false, 'contains-pii': false, 'description': 'SNARE-seq2 [Salmon + ArchR + Muon]', 'is-multi-assay': true}",
+        "value": "{'assaytype': 'multiome-snare-seq2', 'vitessce-hints': ['rna', 'atac', 'anndata', 'is_sc'], 'primary': false, 'contains-pii': false, 'description': 'SNARE-seq2 [Salmon + ArchR + Muon]', 'is-multi-assay': true}",
         "rule_description": "derived multiome snare-seq2"
     }
 ]


### PR DESCRIPTION
Modify vitessce-hints for SNARE-seq2 [Salmon + ArchR + Muon] (rule description "derived multiome snare-seq2") to lose is_image and spatial, and gain atac and is_sc.