### PR TITLE
EPIC dataset assayclassifier rules

### DIFF
--- a/src/soft_assay_rules/testing_rule_chain.json
+++ b/src/soft_assay_rules/testing_rule_chain.json
@@ -769,8 +769,8 @@
     },
     {
         "type": "match",
-        "match": "is_epic and derived_dataset_type == 'segmentation mask'",
-        "value": "{'assaytype': 'segmentation-mask', 'vitessce-hints': [], 'dir-schema': '', 'contains-pii': false, 'primary': false, 'dataset-type': '', 'description': ''}",
+        "match": "is_epic and derived_dataset_type == 'Segmentation Mask'",
+        "value": "{'assaytype': 'segmentation-mask', 'vitessce-hints': [], 'contains-pii': false, 'primary': false, 'dataset-type': 'Segmentation Mask', 'description': 'Segmentation Mask'}",
         "rule_description": "EPIC dataset segmentation mask"
      }
 ]

--- a/src/soft_assay_rules/testing_rule_chain.json
+++ b/src/soft_assay_rules/testing_rule_chain.json
@@ -42,6 +42,12 @@
         "rule_description": "Cover default schema version = 0 for non-DCWG metadata"
     },
     {
+        "type": "note",
+        "match": "creation_action == 'External Process' or (parent_dataset_id != null and derived_dataset_type != null)",
+        "value": "{'is_epic': true}",
+        "rule_description": "Preamble rule identifying EPIC"
+    },
+    {
         "type": "match",
         "match": "not_dcwg and is_primary and assay_type in ['AF']",
         "value": "{'assaytype': 'AF', 'dir-schema': 'af-v0', 'tbl-schema': 'af-v'+version.to_str, 'vitessce-hints': [], 'contains-pii': false, 'primary': true, 'description': 'Autofluorescence Microscopy', 'dataset-type': 'Auto-fluorescence' }",
@@ -760,5 +766,11 @@
         "match": "is_dcwg and is_primary and dataset_type == 'MUSIC'",
         "value": "{'assaytype': 'music', 'vitessce-hints': [], 'dir-schema': 'music-v2', 'contains-pii': true, 'primary': true, 'dataset-type': 'MUSIC', 'description': 'MUSIC'}",
         "rule_description": "DCWG music"
-    }
+    },
+    {
+        "type": "match",
+        "match": "is_epic and derived_dataset_type == 'segmentation mask'",
+        "value": "{'assaytype': 'segmentation-mask', 'vitessce-hints': [], 'dir-schema': '', 'contains-pii': false, 'primary': false, 'dataset-type': '', 'description': ''}",
+        "rule_description": "EPIC dataset segmentation mask"
+     }
 ]


### PR DESCRIPTION
- ~~Unsure of controlled vocab for `derived_dataset_type` field, just used the string from the "Category Field Values" portion of the [Common Derived Dataset Fields spreadsheet](https://docs.google.com/spreadsheets/d/1uAwf5edlXV55tgVeNf3U1MunZW95vy59us6oDoEU2Eg/edit?usp=sharing). Only added segmentation mask for now.~~
- ~~Unsure of appropriate values in rule for segmentation mask, using blank/test values for now. Best guess:
`"value": "{'assaytype': 'segmentation-mask', 'vitessce-hints': [], 'contains-pii': false, 'primary': false, 'dataset-type': 'segmentation mask', 'description': 'segmentation mask'}"`~~
- I see that the `is_central_processed` rules, for example, have unique key/values in the `value`, e.g. `is-multi-assay` and `pipeline-shorthand`. Not sure if we want something like `is-epic` in the value.

Edits based on comments from @jpuerto-psc: changed capitalization to `Segmentation Mask`