### PR TITLE
Add json_based category for scRNA-seq (10x Genomics) [Salmon]

### DIFF
--- a/src/soft_assay_rules/test_examples/salmon_anndata_6efe308f2e7360127e47865edf075424.json
+++ b/src/soft_assay_rules/test_examples/salmon_anndata_6efe308f2e7360127e47865edf075424.json
@@ -1,0 +1,2 @@
+{"creation_action": "Central Process", "dag_provenance_list": ["https://unknown/unknown.git:anndata-to-ui.cwl"], "data_types": ["salmon_rnaseq_10x"], "entity_type": "Dataset"}
+

--- a/src/soft_assay_rules/test_examples/salmon_json_e8d642084fc5ec8b5d348ebab96a4b22.json
+++ b/src/soft_assay_rules/test_examples/salmon_json_e8d642084fc5ec8b5d348ebab96a4b22.json
@@ -1,0 +1,2 @@
+{"creation_action": "Central Process", "dag_provenance_list": ["https://github.com/hubmapconsortium/salmon-rnaseq.git:pipeline.cwl", "https://github.com/hubmapconsortium/portal-containers.git:h5ad-to-arrow.cwl"], "data_types": ["salmon_rnaseq_10x"], "entity_type": "Dataset"}
+

--- a/src/soft_assay_rules/testing_rule_chain.json
+++ b/src/soft_assay_rules/testing_rule_chain.json
@@ -343,9 +343,15 @@
     },
     {
         "type": "match",
-        "match": "is_central_processed and data_types[0] in ['salmon_rnaseq_10x', 'salmon_rnaseq_10x_v2']",
+        "match": "is_central_processed and data_types[0] in ['salmon_rnaseq_10x', 'salmon_rnaseq_10x_v2'] and [elt for elt in dag_provenance_list if elt =~~ 'anndata']",
         "value": "{'assaytype': 'salmon_rnaseq_10x', 'vitessce-hints': ['is_sc', 'rna'], 'primary': false, 'contains-pii': false, 'description': 'scRNA-seq (10x Genomics) [Salmon]'}",
         "rule_description": "derived salmon_rnaseq_10x"
+    },
+    {
+        "type": "match",
+        "match": "is_central_processed and data_types[0] in ['salmon_rnaseq_10x', 'salmon_rnaseq_10x_v2'] and not [elt for elt in dag_provenance_list if elt =~~ 'anndata']",
+        "value": "{'assaytype': 'salmon_rnaseq_10x', 'vitessce-hints': ['is_sc', 'rna', 'json_based'], 'primary': false, 'contains-pii': false, 'description': 'scRNA-seq (10x Genomics) [Salmon]'}",
+        "rule_description": "derived salmon_rnaseq_10x json-based"
     },
     {
         "type": "match",

--- a/tests/test_rule_matches.py
+++ b/tests/test_rule_matches.py
@@ -53,6 +53,20 @@ def test_sample_path():
       'description': 'CODEX [Cytokit + SPRM]',
       'primary': False,
       'vitessce-hints': ('codex', 'is_image', 'is_tiled', 'anndata')}),
+
+    ("salmon_json_e8d642084fc5ec8b5d348ebab96a4b22.json",
+     {'assaytype': 'salmon_rnaseq_10x',
+      'contains-pii': False,
+      'description': 'scRNA-seq (10x Genomics) [Salmon]',
+      'primary': False,
+      'vitessce-hints': ('is_sc', 'rna', 'json_based')}),
+
+    ("salmon_anndata_6efe308f2e7360127e47865edf075424.json",
+     {'assaytype': 'salmon_rnaseq_10x',
+      'contains-pii': False,
+      'description': 'scRNA-seq (10x Genomics) [Salmon]',
+      'primary': False,
+      'vitessce-hints': ('is_sc', 'rna')})
 ))
 def test_rule_match_case(test_sample_path, test_data_fname, expected, tmp_path):
     md_path = test_sample_path / test_data_fname


### PR DESCRIPTION
This PR adds 'json_based' to the Vitessce hints for scRNA-seq (10x Genomics) [Salmon] datasets, as requested 07/25/2024